### PR TITLE
Wordの所得、Recordの保存・所得を実装

### DIFF
--- a/src/main/java/com/programming/advanced/wordle/dao/RecordDAO.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/RecordDAO.java
@@ -4,6 +4,8 @@ import com.programming.advanced.wordle.model.Record;
 import com.programming.advanced.wordle.model.RecordDTO;
 import java.sql.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 // 記録データアクセスオブジェクト
 public class RecordDAO {
@@ -65,5 +67,36 @@ public class RecordDAO {
                 conn.setAutoCommit(true); // 自動コミットを元に戻す
             }
         }
+    }
+
+    /**
+     * すべての記録を取得します
+     * @return 記録のリスト
+     * @throws SQLException データベースアクセスエラーが発生した場合
+     */
+    public List<Record> getAllRecords() throws SQLException {
+        String sql = "SELECT r.*, w.word FROM records r " +
+                    "JOIN words w ON r.wordId = w.id " +
+                    "ORDER BY r.date DESC, r.id DESC";
+        
+        List<Record> records = new ArrayList<>();
+        
+        try (Connection conn = DatabaseInitializer.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql);
+             ResultSet rs = pstmt.executeQuery()) {
+            
+            while (rs.next()) {
+                Record record = new Record();
+                record.setId(rs.getInt("id"));
+                record.setWordId(rs.getInt("wordId"));
+                record.setWord(rs.getString("word"));
+                record.setAnswerCount(rs.getInt("answerCount"));
+                record.setClear(rs.getBoolean("clear"));
+                record.setDate(rs.getDate("date").toLocalDate());
+                records.add(record);
+            }
+        }
+        
+        return records;
     }
 }

--- a/src/main/java/com/programming/advanced/wordle/dao/RecordDAO.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/RecordDAO.java
@@ -1,6 +1,69 @@
 package com.programming.advanced.wordle.dao;
 
+import com.programming.advanced.wordle.model.Record;
+import com.programming.advanced.wordle.model.RecordDTO;
+import java.sql.*;
+import java.time.LocalDate;
+
 // 記録データアクセスオブジェクト
 public class RecordDAO {
-    // TODO: 記録データの取得・保存
+    
+    /**
+     * プレイ記録を保存し、単語の統計情報を更新します
+     * @param dto 保存する記録のDTO
+     * @return 保存された記録のID
+     * @throws SQLException データベースアクセスエラーが発生した場合
+     */
+    public int saveRecord(RecordDTO dto) throws SQLException {
+        String insertRecordSql = "INSERT INTO records (wordId, answerCount, clear, date) VALUES (?, ?, ?, ?)";
+        String updateWordStatsSql = "UPDATE words SET playCount = playCount + 1, " +
+                                  "clearCount = clearCount + ?, " +
+                                  "missCount = missCount + ? " +
+                                  "WHERE id = ?";
+        
+        try (Connection conn = DatabaseInitializer.getConnection()) {
+            conn.setAutoCommit(false); // トランザクション開始
+            
+            try {
+                // レコードの保存
+                int recordId;
+                try (PreparedStatement pstmt = conn.prepareStatement(insertRecordSql, Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setInt(1, dto.getWordId());
+                    pstmt.setInt(2, dto.getAnswerCount());
+                    pstmt.setBoolean(3, dto.isClear());
+                    pstmt.setDate(4, Date.valueOf(LocalDate.now())); // 現在の日付を自動設定
+                    
+                    pstmt.executeUpdate();
+                    
+                    try (ResultSet rs = pstmt.getGeneratedKeys()) {
+                        if (rs.next()) {
+                            recordId = rs.getInt(1);
+                        } else {
+                            throw new SQLException("レコードの保存に失敗しました");
+                        }
+                    }
+                }
+                
+                // 単語の統計情報を更新
+                try (PreparedStatement pstmt = conn.prepareStatement(updateWordStatsSql)) {
+                    // clearCountの更新値（クリアした場合は1、失敗した場合は0）
+                    pstmt.setInt(1, dto.isClear() ? 1 : 0);
+                    // missCountの更新値（失敗した場合は1、クリアした場合は0）
+                    pstmt.setInt(2, dto.isClear() ? 0 : 1);
+                    pstmt.setInt(3, dto.getWordId());
+                    
+                    pstmt.executeUpdate();
+                }
+                
+                conn.commit(); // トランザクションをコミット
+                return recordId;
+                
+            } catch (SQLException e) {
+                conn.rollback(); // エラーが発生した場合はロールバック
+                throw e;
+            } finally {
+                conn.setAutoCommit(true); // 自動コミットを元に戻す
+            }
+        }
+    }
 }

--- a/src/main/java/com/programming/advanced/wordle/dao/RecordDAOTest.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/RecordDAOTest.java
@@ -1,8 +1,10 @@
 package com.programming.advanced.wordle.dao;
 
+import com.programming.advanced.wordle.model.Record;
 import com.programming.advanced.wordle.model.RecordDTO;
 import com.programming.advanced.wordle.model.Word;
 import java.sql.*;
+import java.util.List;
 
 public class RecordDAOTest {
     public static void main(String[] args) {
@@ -48,6 +50,18 @@ public class RecordDAOTest {
             word = wordDAO.getWordById(wordId);
             System.out.printf("\n更新後の統計: プレイ回数=%d, 正解回数=%d, 失敗回数=%d%n",
                 word.getPlayCount(), word.getClearCount(), word.getMissCount());
+            
+            // 全レコード取得のテスト
+            System.out.println("\n全レコード取得のテストを開始します...");
+            List<Record> records = recordDAO.getAllRecords();
+            System.out.printf("取得したレコード数: %d%n", records.size());
+            
+            System.out.println("\nレコード一覧:");
+            for (Record r : records) {
+                System.out.printf("ID: %d, 単語: %s, 回答回数: %d, クリア: %s, 日付: %s%n",
+                    r.getId(), r.getWord(), r.getAnswerCount(),
+                    r.isClear() ? "成功" : "失敗", r.getDate());
+            }
             
             System.out.println("\nテストが正常に完了しました。");
             

--- a/src/main/java/com/programming/advanced/wordle/dao/RecordDAOTest.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/RecordDAOTest.java
@@ -1,0 +1,59 @@
+package com.programming.advanced.wordle.dao;
+
+import com.programming.advanced.wordle.model.RecordDTO;
+import com.programming.advanced.wordle.model.Word;
+import java.sql.*;
+
+public class RecordDAOTest {
+    public static void main(String[] args) {
+        try {
+            // データベースの初期化
+            System.out.println("データベースの初期化を開始します...");
+            DatabaseInitializer.initializeDatabase();
+            
+            // RecordDAOのテスト
+            System.out.println("\nRecordDAOのテストを開始します...");
+            RecordDAO recordDAO = new RecordDAO();
+            WordDAO wordDAO = new WordDAO();
+            
+            // テスト用の単語を取得
+            Word word = wordDAO.getRandomWord();
+            int wordId = word.getId(); // 単語IDを保存
+            System.out.printf("\nテスト対象の単語: ID=%d, 単語=%s%n", word.getId(), word.getWord());
+            System.out.printf("現在の統計: プレイ回数=%d, 正解回数=%d, 失敗回数=%d%n",
+                word.getPlayCount(), word.getClearCount(), word.getMissCount());
+            
+            // テスト用の記録を作成（クリア）
+            RecordDTO record = new RecordDTO(wordId, 3, true); // 3回で正解
+            
+            // 記録を保存
+            System.out.println("\n記録を保存します（クリア）：");
+            int recordId = recordDAO.saveRecord(record);
+            System.out.printf("保存された記録のID: %d%n", recordId);
+            
+            // 統計情報の更新を確認（同じ単語をIDで取得）
+            word = wordDAO.getWordById(wordId);
+            System.out.printf("\n更新後の統計: プレイ回数=%d, 正解回数=%d, 失敗回数=%d%n",
+                word.getPlayCount(), word.getClearCount(), word.getMissCount());
+            
+            // 失敗の記録も作成
+            RecordDTO failRecord = new RecordDTO(wordId, 6, false); // 6回で失敗
+            
+            // 失敗の記録を保存
+            System.out.println("\n記録を保存します（失敗）：");
+            recordId = recordDAO.saveRecord(failRecord);
+            System.out.printf("保存された記録のID: %d%n", recordId);
+            
+            // 統計情報の更新を確認（同じ単語をIDで取得）
+            word = wordDAO.getWordById(wordId);
+            System.out.printf("\n更新後の統計: プレイ回数=%d, 正解回数=%d, 失敗回数=%d%n",
+                word.getPlayCount(), word.getClearCount(), word.getMissCount());
+            
+            System.out.println("\nテストが正常に完了しました。");
+            
+        } catch (Exception e) {
+            System.err.println("テスト中にエラーが発生しました:");
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/programming/advanced/wordle/dao/WordDAO.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/WordDAO.java
@@ -32,4 +32,34 @@ public class WordDAO {
             throw new SQLException("単語が見つかりません");
         }
     }
+
+    /**
+     * 指定されたIDの単語を取得します
+     * @param id 取得する単語のID
+     * @return 指定されたIDの単語
+     * @throws SQLException データベースアクセスエラーが発生した場合
+     */
+    public Word getWordById(int id) throws SQLException {
+        String sql = "SELECT * FROM words WHERE id = ?";
+        
+        try (Connection conn = DatabaseInitializer.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            
+            pstmt.setInt(1, id);
+            
+            try (ResultSet rs = pstmt.executeQuery()) {
+                if (rs.next()) {
+                    return new Word(
+                        rs.getInt("id"),
+                        rs.getString("word"),
+                        rs.getInt("playCount"),
+                        rs.getInt("clearCount"),
+                        rs.getInt("missCount")
+                    );
+                }
+                
+                throw new SQLException("ID=" + id + "の単語が見つかりません");
+            }
+        }
+    }
 }

--- a/src/main/java/com/programming/advanced/wordle/dao/WordDAO.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/WordDAO.java
@@ -1,6 +1,35 @@
 package com.programming.advanced.wordle.dao;
 
+import com.programming.advanced.wordle.model.Word;
+import java.sql.*;
+
 // 単語データアクセスオブジェクト
 public class WordDAO {
     // TODO: 単語データの取得・保存
+    
+    /**
+     * データベースからランダムな単語を1つ取得します
+     * @return ランダムな単語
+     * @throws SQLException データベースアクセスエラーが発生した場合
+     */
+    public Word getRandomWord() throws SQLException {
+        String sql = "SELECT * FROM words ORDER BY RANDOM() LIMIT 1";
+        
+        try (Connection conn = DatabaseInitializer.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql);
+             ResultSet rs = pstmt.executeQuery()) {
+            
+            if (rs.next()) {
+                return new Word(
+                    rs.getInt("id"),
+                    rs.getString("word"),
+                    rs.getInt("playCount"),
+                    rs.getInt("clearCount"),
+                    rs.getInt("missCount")
+                );
+            }
+            
+            throw new SQLException("単語が見つかりません");
+        }
+    }
 }

--- a/src/main/java/com/programming/advanced/wordle/dao/WordDAOTest.java
+++ b/src/main/java/com/programming/advanced/wordle/dao/WordDAOTest.java
@@ -1,0 +1,38 @@
+package com.programming.advanced.wordle.dao;
+
+import com.programming.advanced.wordle.model.Word;
+import java.sql.SQLException;
+
+public class WordDAOTest {
+    public static void main(String[] args) {
+        try {
+            // データベースの初期化
+            System.out.println("データベースの初期化を開始します...");
+            DatabaseInitializer.initializeDatabase();
+            
+            // WordDAOのテスト
+            System.out.println("\nWordDAOのテストを開始します...");
+            WordDAO wordDAO = new WordDAO();
+            
+            // ランダムな単語を5回取得してテスト
+            System.out.println("\nランダムな単語を5回取得します：");
+            for (int i = 0; i < 5; i++) {
+                Word word = wordDAO.getRandomWord();
+                System.out.printf("取得%d: ID=%d, 単語=%s, 出題回数=%d, 正解回数=%d, 失敗回数=%d%n",
+                    i + 1,
+                    word.getId(),
+                    word.getWord(),
+                    word.getPlayCount(),
+                    word.getClearCount(),
+                    word.getMissCount()
+                );
+            }
+            
+            System.out.println("\nテストが正常に完了しました。");
+            
+        } catch (Exception e) {
+            System.err.println("テスト中にエラーが発生しました:");
+            e.printStackTrace();
+        }
+    }
+} 

--- a/src/main/java/com/programming/advanced/wordle/model/Record.java
+++ b/src/main/java/com/programming/advanced/wordle/model/Record.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 public class Record {
     private int id; // レコードID
     private int wordId; // 出題語のID
+    private String word;        // 単語の文字列
     private int answerCount; // 回答回数（最大6）
     private boolean clear; // 正解したか否か
     private LocalDate date; // プレイ日付
@@ -13,9 +14,10 @@ public class Record {
     public Record() {
     }
 
-    public Record(int id, int wordId, int answerCount, boolean clear, LocalDate date) {
+    public Record(int id, int wordId, String word, int answerCount, boolean clear, LocalDate date) {
         this.id = id;
         this.wordId = wordId;
+        this.word = word;
         this.answerCount = answerCount;
         this.clear = clear;
         this.date = date;
@@ -35,6 +37,14 @@ public class Record {
 
     public void setWordId(int wordId) {
         this.wordId = wordId;
+    }
+
+    public String getWord() {
+        return word;
+    }
+
+    public void setWord(String word) {
+        this.word = word;
     }
 
     public int getAnswerCount() {

--- a/src/main/java/com/programming/advanced/wordle/model/RecordDTO.java
+++ b/src/main/java/com/programming/advanced/wordle/model/RecordDTO.java
@@ -1,0 +1,41 @@
+package com.programming.advanced.wordle.model;
+
+// レコードの受け渡し用DTO
+public class RecordDTO {
+    private int wordId;        // 出題された単語のID
+    private int answerCount;   // 回答回数
+    private boolean clear;     // 正解したかどうか
+
+    public RecordDTO() {
+    }
+
+    public RecordDTO(int wordId, int answerCount, boolean clear) {
+        this.wordId = wordId;
+        this.answerCount = answerCount;
+        this.clear = clear;
+    }
+
+    public int getWordId() {
+        return wordId;
+    }
+
+    public void setWordId(int wordId) {
+        this.wordId = wordId;
+    }
+
+    public int getAnswerCount() {
+        return answerCount;
+    }
+
+    public void setAnswerCount(int answerCount) {
+        this.answerCount = answerCount;
+    }
+
+    public boolean isClear() {
+        return clear;
+    }
+
+    public void setClear(boolean clear) {
+        this.clear = clear;
+    }
+} 


### PR DESCRIPTION
## 変更内容

### 1. `RecordDTO`クラスの作成
- レコード保存に必要な最小限の情報を保持
  - 単語ID
  - 回答回数
  - クリア状態
- 日付は自動設定されるため、DTOには含めない

### 2. `RecordDAO`クラスの機能拡張
#### `saveRecord`メソッドの改善
- `RecordDTO`を使用して記録を保存
- トランザクション管理による安全なデータ更新
- 単語の統計情報の自動更新
  - プレイ回数
  - クリア回数
  - 失敗回数

#### `getAllRecords`メソッドの追加
- すべての記録を日付の降順で取得
- 単語の文字列も含めて取得（JOINクエリ）

### 3. `Record`クラスの拡張
- 単語の文字列を保持する機能を追加
- より詳細な情報を表示可能に

### 4. `getRandomWoerd`メソッドの追加
- ランダムでWordを所得

### 5. テストの実装
- `RecordDAOTest`クラスによる機能テスト
  - 記録の保存と統計情報の更新の確認
  - 全レコード取得機能のテスト
