### PR TITLE
レポート用のTeXを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target/
 wordle.db
+
+report/*
+!report/report.tex

--- a/report/report.tex
+++ b/report/report.tex
@@ -1,0 +1,36 @@
+\documentclass[a4j]{ujarticle}
+
+\usepackage[dvipdfmx]{graphicx}
+\usepackage{graphicx}
+\usepackage{url}
+\usepackage{listings}
+\usepackage{ascmac}
+\usepackage{amsmath,amssymb}
+
+\lstset{
+  basicstyle={\ttfamily},
+  identifierstyle={\small},
+  commentstyle={\small\itshape},
+  keywordstyle={\small\bfseries},
+  ndkeywordstyle={\small},
+  stringstyle={\small\ttfamily},
+  frame={tb},
+  breaklines=true,
+  columns=[l]{fullflexible},
+  numbers=left,
+  xrightmargin=0zw,
+  xleftmargin=3zw,
+  numberstyle={\scriptsize},
+  stepnumber=1,
+  numbersep=1zw,
+  lineskip=-0.5ex
+}
+
+\title{タイトル}
+\author{名前}
+\date{\today}
+\begin{document}
+\maketitle
+\section{問題1}
+
+\end{document}


### PR DESCRIPTION
# 概要
レポート用のTeXを追加した。なお、初期から追加されているレイアウトについては下記の写真を参照されたし。

![スクリーンショット 2025-05-24 004147](https://github.com/user-attachments/assets/065bcb33-eafa-4ab6-8da2-d53d7359dc66)

（普段テンプレとして使っているものを勝手に追加しただけなので、気に入らなかったら上書きしてください）

# 細かな変更点
- レポート用のTeXを追加した

# 既存の箇所への影響範囲
なし